### PR TITLE
Generate theme types before building storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "pnpm eslint && pnpm prettier-check",
     "type-check": "tsc --build",
     "storybook": "storybook dev -p 6006",
+    "prebuild-storybook": "pnpm generate-theme",
     "build-storybook": "storybook build",
     "test": "vitest --project=storybook",
     "prerelease": "pnpm build",


### PR DESCRIPTION
Generate the theme types before building storybook so in CI it doesn't publish without the auto generated documentation

<img width="1116" height="715" alt="image" src="https://github.com/user-attachments/assets/97f85de7-63b2-4fcb-9716-d69a61035c6d" />
