### PR TITLE
Prevent storybook from flash banging when navigating between docs

### DIFF
--- a/.storybook/storybookTheme.ts
+++ b/.storybook/storybookTheme.ts
@@ -32,6 +32,24 @@ const globalStorybookCss = defineGlobalStyles({
       color: 'text.muted',
     },
   },
+  'div.sb-preparing-docs.sb-wrapper, div.sb-preparing-story': {
+    backgroundColor: '{colors.levels.sunken} !important',
+  },
+  'div.sb-previewBlock': {
+    backgroundColor: '{colors.levels.elevated} !important',
+  },
+  '.sb-argstableBlock th span, .sb-argstableBlock td span': {
+    backgroundColor: '{colors.interactive.tonal.neutral.1} !important',
+  },
+  '.sb-argstableBlock-body td': {
+    background: '{colors.levels.elevated} !important',
+  },
+  '.sb-argstableBlock-body tr:not(:first-child)': {
+    borderTopColor: '{colors.interactive.tonal.neutral.2} !important',
+  },
+  '.sb-loader': {
+    color: '{colors.text.main} !important',
+  },
 });
 
 const colors = defineSemanticTokens.colors({


### PR DESCRIPTION
This overrides a bunch of Storybook CSS to prevent the preparing docs wrapper from flashing white between page navigation, which was quite obvious when browsing using a dark theme