### PR TITLE
Change Storybook preview workflows to use artifacts

### DIFF
--- a/.github/actions/fetch-pr-previews/action.yml
+++ b/.github/actions/fetch-pr-previews/action.yml
@@ -1,0 +1,68 @@
+name: 'Fetch PR Previews Artifact'
+description: 'Fetches the latest PR previews artifact from either storybook-preview.yml or storybook-cleanup.yml workflows'
+outputs:
+  found:
+    description: 'Whether the artifact was found'
+    value: ${{ steps.get-pr-run.outputs.found }}
+  run-id:
+    description: 'The workflow run ID where the artifact was found'
+    value: ${{ steps.get-pr-run.outputs.run_id }}
+  workflow-name:
+    description: 'The name of the workflow where the artifact was found'
+    value: ${{ steps.get-pr-run.outputs.workflow_name }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Get latest PR previews from previous runs
+      id: get-pr-run
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // Get previous successful runs from both preview and cleanup workflows
+          const [previewRuns, cleanupRuns] = await Promise.all([
+            github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/storybook-preview.yml',
+              status: 'success',
+              per_page: 5
+            }),
+            github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/storybook-cleanup.yml',
+              status: 'success',
+              per_page: 5
+            })
+          ]);
+
+          // Combine and sort by created_at to find the most recent
+          const allRuns = [
+            ...previewRuns.data.workflow_runs,
+            ...cleanupRuns.data.workflow_runs
+          ].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+          // Get the most recent successful run
+          const targetRun = allRuns[0];
+
+          if (targetRun) {
+            const runId = targetRun.id;
+            console.log(`Found PR previews run: ${runId} from ${targetRun.name}`);
+            core.setOutput('run_id', runId);
+            core.setOutput('found', 'true');
+            core.setOutput('workflow_name', targetRun.name);
+          } else {
+            console.log('No PR preview runs found');
+            core.setOutput('found', 'false');
+          }
+
+    - name: Download PR previews artifact
+      if: steps.get-pr-run.outputs.found == 'true'
+      uses: actions/download-artifact@v5
+      with:
+        name: storybook-pr-previews
+        path: ./pr-previews
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ steps.get-pr-run.outputs.run_id }}
+      continue-on-error: true

--- a/.github/actions/fetch-storybook-main/action.yml
+++ b/.github/actions/fetch-storybook-main/action.yml
@@ -1,0 +1,46 @@
+name: 'Fetch Main Storybook Artifact'
+description: 'Fetches the latest main storybook artifact from the storybook.yml workflow'
+outputs:
+  found:
+    description: 'Whether the artifact was found'
+    value: ${{ steps.get-main-run.outputs.found }}
+  run-id:
+    description: 'The workflow run ID where the artifact was found'
+    value: ${{ steps.get-main-run.outputs.run_id }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Get latest main storybook workflow run
+      id: get-main-run
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const runs = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: '.github/workflows/storybook.yml',
+            branch: 'main',
+            status: 'success',
+            per_page: 1
+          });
+
+          if (runs.data.workflow_runs.length > 0) {
+            const runId = runs.data.workflow_runs[0].id;
+            console.log(`Found main storybook run: ${runId}`);
+            core.setOutput('run_id', runId);
+            core.setOutput('found', 'true');
+          } else {
+            console.log('No main storybook runs found');
+            core.setOutput('found', 'false');
+          }
+
+    - name: Download main storybook artifact
+      if: steps.get-main-run.outputs.found == 'true'
+      uses: actions/download-artifact@v5
+      with:
+        name: storybook-main
+        path: ./storybook-static-main
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ steps.get-main-run.outputs.run_id }}
+      continue-on-error: true

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -29,7 +29,7 @@ jobs:
           path: ./main-storybook
           key: storybook-main
           restore-keys: |
-            storybook-main-
+            storybook-main
 
       - name: Restore PR previews from cache
         uses: actions/cache/restore@v4
@@ -37,7 +37,7 @@ jobs:
           path: ./pr-previews
           key: storybook-pr-previews
           restore-keys: |
-            storybook-pr-previews-
+            storybook-pr-previews
 
       - name: Remove PR preview
         run: |

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -51,6 +51,7 @@ jobs:
           name: storybook-pr-previews
           path: ./pr-previews
           retention-days: 30
+          overwrite: true
 
       - name: Combine main storybook with remaining PR previews
         run: |
@@ -72,10 +73,27 @@ jobs:
             echo "No PR previews remaining"
           fi
 
-      - name: Upload combined pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Archive pages artifact
+        shell: sh
+        run: |
+          echo ::group::Archive artifact
+          tar \
+            --dereference --hard-dereference \
+            --directory "./combined-pages" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=".[^/]*" \
+            .
+          echo ::endgroup::
+
+      - name: Upload pages artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: './combined-pages'
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          overwrite: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/storybook-cleanup.yml
+++ b/.github/workflows/storybook-cleanup.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -23,21 +24,14 @@ jobs:
     name: Remove PR preview
     runs-on: ubuntu-latest
     steps:
-      - name: Restore main storybook from cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ./main-storybook
-          key: storybook-main
-          restore-keys: |
-            storybook-main
+      - name: Checkout branch
+        uses: actions/checkout@v5
 
-      - name: Restore PR previews from cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ./pr-previews
-          key: storybook-pr-previews
-          restore-keys: |
-            storybook-pr-previews
+      - name: Fetch main storybook
+        uses: ./.github/actions/fetch-storybook-main
+
+      - name: Fetch previous PR previews
+        uses: ./.github/actions/fetch-pr-previews
 
       - name: Remove PR preview
         run: |
@@ -51,20 +45,21 @@ jobs:
             echo "No preview found for PR #${PR_NUMBER}"
           fi
 
-      - name: Save updated PR previews to cache
-        uses: actions/cache/save@v4
+      - name: Upload updated PR previews artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: storybook-pr-previews
           path: ./pr-previews
-          key: storybook-pr-previews
+          retention-days: 30
 
       - name: Combine main storybook with remaining PR previews
         run: |
           mkdir -p ./combined-pages
 
-          # Add main storybook if it exists in cache
-          if [ -d ./main-storybook ]; then
-            cp -r ./main-storybook/* ./combined-pages/
-            echo "Added main storybook from cache"
+          # Add main storybook if it exists
+          if [ -d ./storybook-static-main ]; then
+            cp -r ./storybook-static-main/* ./combined-pages/
+            echo "Added main storybook"
           else
             echo "Warning: No main storybook found. Main branch needs to be deployed."
           fi
@@ -77,7 +72,7 @@ jobs:
             echo "No PR previews remaining"
           fi
 
-      - name: Upload updated artifact
+      - name: Upload combined pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: './combined-pages'

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -35,79 +35,11 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
-      - name: Get latest main storybook workflow run
-        id: get-main-run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: '.github/workflows/storybook.yml',
-              branch: 'main',
-              status: 'success',
-              per_page: 1
-            });
+      - name: Fetch main storybook
+        uses: ./.github/actions/fetch-storybook-main
 
-            if (runs.data.workflow_runs.length > 0) {
-              const runId = runs.data.workflow_runs[0].id;
-              console.log(`Found main storybook run: ${runId}`);
-              core.setOutput('run_id', runId);
-              core.setOutput('found', 'true');
-            } else {
-              console.log('No main storybook runs found');
-              core.setOutput('found', 'false');
-            }
-
-      - name: Download main storybook artifact
-        if: steps.get-main-run.outputs.found == 'true'
-        uses: actions/download-artifact@v5
-        continue-on-error: true
-        with:
-          name: storybook-main
-          path: ./storybook-static-main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.get-main-run.outputs.run_id }}
-
-      - name: Get latest PR previews from previous runs
-        id: get-previous-pr-run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Get previous successful runs of this workflow (excluding current)
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: '.github/workflows/storybook-preview.yml',
-              status: 'success',
-              per_page: 10
-            });
-
-            // Find the most recent run that's not the current one
-            const currentRunId = context.runId;
-            const previousRun = runs.data.workflow_runs.find(run => run.id !== currentRunId);
-
-            if (previousRun) {
-              const runId = previousRun.id;
-              console.log(`Found previous PR preview run: ${runId}`);
-              core.setOutput('run_id', runId);
-              core.setOutput('found', 'true');
-            } else {
-              console.log('No previous PR preview runs found');
-              core.setOutput('found', 'false');
-            }
-
-      - name: Download previous PR previews artifact
-        if: steps.get-previous-pr-run.outputs.found == 'true'
-        uses: actions/download-artifact@v5
-        continue-on-error: true
-        with:
-          name: storybook-pr-previews
-          path: ./pr-previews
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.get-previous-pr-run.outputs.run_id }}
+      - name: Fetch previous PR previews
+        uses: ./.github/actions/fetch-pr-previews
 
       - name: Add current PR storybook to previews
         run: |
@@ -123,7 +55,7 @@ jobs:
           echo "Added PR #${PR_NUMBER} preview"
 
       - name: Upload PR previews artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-pr-previews
           path: ./pr-previews

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -60,6 +60,7 @@ jobs:
           name: storybook-pr-previews
           path: ./pr-previews
           retention-days: 30
+          overwrite: true
 
       - name: Combine main storybook with PR previews
         run: |
@@ -79,10 +80,27 @@ jobs:
             echo "Added PR previews to combined pages"
           fi
 
-      - name: Upload combined pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Archive pages artifact
+        shell: sh
+        run: |
+          echo ::group::Archive artifact
+          tar \
+            --dereference --hard-dereference \
+            --directory "./combined-pages" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=".[^/]*" \
+            .
+          echo ::endgroup::
+
+      - name: Upload pages artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: './combined-pages'
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          overwrite: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -40,7 +40,7 @@ jobs:
           path: ./storybook-static-main
           key: storybook-main
           restore-keys: |
-            storybook-main-
+            storybook-main
 
       - name: Restore PR previews from cache
         uses: actions/cache/restore@v4
@@ -48,7 +48,7 @@ jobs:
           path: ./pr-previews
           key: storybook-pr-previews
           restore-keys: |
-            storybook-pr-previews-
+            storybook-pr-previews
 
       - name: Add PR storybook to previews
         run: |

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -34,23 +35,81 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
-      - name: Restore main storybook from cache
-        uses: actions/cache/restore@v4
+      - name: Get latest main storybook workflow run
+        id: get-main-run
+        uses: actions/github-script@v7
         with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/storybook.yml',
+              branch: 'main',
+              status: 'success',
+              per_page: 1
+            });
+
+            if (runs.data.workflow_runs.length > 0) {
+              const runId = runs.data.workflow_runs[0].id;
+              console.log(`Found main storybook run: ${runId}`);
+              core.setOutput('run_id', runId);
+              core.setOutput('found', 'true');
+            } else {
+              console.log('No main storybook runs found');
+              core.setOutput('found', 'false');
+            }
+
+      - name: Download main storybook artifact
+        if: steps.get-main-run.outputs.found == 'true'
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: storybook-main
           path: ./storybook-static-main
-          key: storybook-main
-          restore-keys: |
-            storybook-main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-main-run.outputs.run_id }}
 
-      - name: Restore PR previews from cache
-        uses: actions/cache/restore@v4
+      - name: Get latest PR previews from previous runs
+        id: get-previous-pr-run
+        uses: actions/github-script@v7
         with:
-          path: ./pr-previews
-          key: storybook-pr-previews
-          restore-keys: |
-            storybook-pr-previews
+          script: |
+            // Get previous successful runs of this workflow (excluding current)
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/storybook-preview.yml',
+              status: 'success',
+              per_page: 10
+            });
 
-      - name: Add PR storybook to previews
+            // Find the most recent run that's not the current one
+            const currentRunId = context.runId;
+            const previousRun = runs.data.workflow_runs.find(run => run.id !== currentRunId);
+
+            if (previousRun) {
+              const runId = previousRun.id;
+              console.log(`Found previous PR preview run: ${runId}`);
+              core.setOutput('run_id', runId);
+              core.setOutput('found', 'true');
+            } else {
+              console.log('No previous PR preview runs found');
+              core.setOutput('found', 'false');
+            }
+
+      - name: Download previous PR previews artifact
+        if: steps.get-previous-pr-run.outputs.found == 'true'
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: storybook-pr-previews
+          path: ./pr-previews
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-previous-pr-run.outputs.run_id }}
+
+      - name: Add current PR storybook to previews
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
@@ -63,20 +122,21 @@ jobs:
           cp -r ./storybook-static/* ./pr-previews/${PR_NUMBER}/
           echo "Added PR #${PR_NUMBER} preview"
 
-      - name: Save PR previews to cache
-        uses: actions/cache/save@v4
+      - name: Upload PR previews artifact
+        uses: actions/upload-artifact@v5
         with:
+          name: storybook-pr-previews
           path: ./pr-previews
-          key: storybook-pr-previews
+          retention-days: 30
 
       - name: Combine main storybook with PR previews
         run: |
           mkdir -p ./combined-pages
 
-          # Add main storybook if it exists in cache
+          # Add main storybook if it exists
           if [ -d ./storybook-static-main ]; then
             cp -r ./storybook-static-main/* ./combined-pages/
-            echo "Added main storybook from cache"
+            echo "Added main storybook"
           else
             echo "Warning: No main storybook found. Main branch needs to be deployed."
           fi

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -40,7 +40,7 @@ jobs:
           path: ./pr-previews
           key: storybook-pr-previews
           restore-keys: |
-            storybook-pr-previews-
+            storybook-pr-previews
 
       - name: Save main storybook to cache
         uses: actions/cache/save@v4

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -34,19 +35,46 @@ jobs:
       - name: Build
         run: pnpm build-storybook
 
-      - name: Restore PR previews from cache
-        uses: actions/cache/restore@v4
+      - name: Upload main storybook artifact
+        uses: actions/upload-artifact@v5
         with:
-          path: ./pr-previews
-          key: storybook-pr-previews
-          restore-keys: |
-            storybook-pr-previews
-
-      - name: Save main storybook to cache
-        uses: actions/cache/save@v4
-        with:
+          name: storybook-main
           path: ./storybook-static
-          key: storybook-main
+          retention-days: 30
+
+      - name: Get latest PR preview workflow run
+        id: get-pr-run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/storybook-preview.yml',
+              status: 'success',
+              per_page: 1
+            });
+
+            if (runs.data.workflow_runs.length > 0) {
+              const runId = runs.data.workflow_runs[0].id;
+              console.log(`Found PR preview run: ${runId}`);
+              core.setOutput('run_id', runId);
+              core.setOutput('found', 'true');
+            } else {
+              console.log('No PR preview runs found');
+              core.setOutput('found', 'false');
+            }
+
+      - name: Download PR previews artifact
+        if: steps.get-pr-run.outputs.found == 'true'
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: storybook-pr-previews
+          path: ./pr-previews
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-pr-run.outputs.run_id }}
 
       - name: Combine main storybook with PR previews
         run: |
@@ -55,15 +83,15 @@ jobs:
           # Add main storybook
           cp -r ./storybook-static/* ./combined-pages/
 
-          # Restore PR previews if they exist in cache
+          # Add PR previews if they exist
           if [ -d ./pr-previews ]; then
             cp -r ./pr-previews ./combined-pages/pr
-            echo "Restored PR previews from cache"
+            echo "Added PR previews to combined pages"
           else
-            echo "No PR previews found in cache"
+            echo "No PR previews found"
           fi
 
-      - name: Upload Artifact
+      - name: Upload combined pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: './combined-pages'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -41,6 +41,7 @@ jobs:
           name: storybook-main
           path: ./storybook-static
           retention-days: 30
+          overwrite: true
 
       - name: Fetch PR previews
         uses: ./.github/actions/fetch-pr-previews
@@ -60,10 +61,27 @@ jobs:
             echo "No PR previews found"
           fi
 
-      - name: Upload combined pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Archive pages artifact
+        shell: sh
+        run: |
+          echo ::group::Archive artifact
+          tar \
+            --dereference --hard-dereference \
+            --directory "./combined-pages" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=".[^/]*" \
+            .
+          echo ::endgroup::
+
+      - name: Upload pages artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: './combined-pages'
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          overwrite: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -36,45 +36,14 @@ jobs:
         run: pnpm build-storybook
 
       - name: Upload main storybook artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-main
           path: ./storybook-static
           retention-days: 30
 
-      - name: Get latest PR preview workflow run
-        id: get-pr-run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: '.github/workflows/storybook-preview.yml',
-              status: 'success',
-              per_page: 1
-            });
-
-            if (runs.data.workflow_runs.length > 0) {
-              const runId = runs.data.workflow_runs[0].id;
-              console.log(`Found PR preview run: ${runId}`);
-              core.setOutput('run_id', runId);
-              core.setOutput('found', 'true');
-            } else {
-              console.log('No PR preview runs found');
-              core.setOutput('found', 'false');
-            }
-
-      - name: Download PR previews artifact
-        if: steps.get-pr-run.outputs.found == 'true'
-        uses: actions/download-artifact@v5
-        continue-on-error: true
-        with:
-          name: storybook-pr-previews
-          path: ./pr-previews
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.get-pr-run.outputs.run_id }}
+      - name: Fetch PR previews
+        uses: ./.github/actions/fetch-pr-previews
 
       - name: Combine main storybook with PR previews
         run: |


### PR DESCRIPTION
The cache doesn't work because it can't be shared between feature branches. This updates it to use artifacts, published by the workflows. The workflow will grab the latest run of the relevant workflow (main deploy, PR preview deploy) when building and download the previously deployed Storybook state from there

This will all disappear once GitHub pages allows previews (currently in alpha)