### PR TITLE
Add root to pnpm workspace to appease changesets

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - '.'
   - 'bot'
   - 'crates/*'
 onlyBuiltDependencies:


### PR DESCRIPTION
Not sure why this wasn't erroring before but changesets now needs the pnpm workspace to include root