### PR TITLE
CI workflow updates

### DIFF
--- a/.github/workflows/check-reviewers.yml
+++ b/.github/workflows/check-reviewers.yml
@@ -2,7 +2,7 @@ name: Bot
 
 on:
   pull_request_review:
-    type: [ submitted, edited, dismissed ]
+    types: [ submitted, edited, dismissed ]
   pull_request:
     types: [ opened, ready_for_review, synchronize, reopened ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 env:
   NODE_VERSION: 22.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/libraries.yml
+++ b/.github/workflows/libraries.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 env:
   NODE_VERSION: 22.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - ".changeset/**"
-      - ".github/workflows/release.yml"
-      - "crates/**"
-      - "src/**"
     branches:
       - main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: 22.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   release:
+    if: github.ref == 'refs/heads/main'
     name: Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
- Allow the release workflow to be triggered manually
- Removes the paths from release workflow so it always runs 
- Add merge_group to PR related workflows so we can enable the merge queue in the repo