### PR TITLE
Add helpers for resolving theme token values

### DIFF
--- a/.changeset/bold-turkeys-burn.md
+++ b/.changeset/bold-turkeys-burn.md
@@ -1,0 +1,5 @@
+---
+'@gravitational/design-system': patch
+---
+
+Add `resolveColorToken` and `resolveTeleportColor` helpers

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,5 +17,5 @@
   "tabWidth": 2,
   "trailingComma": "es5",
   "sortPackageJson": false,
-  "ignorePatterns": []
+  "ignorePatterns": [".changeset/"]
 }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -46,3 +46,5 @@ export type SingleColorTheme<T> = T extends TokenSchema
     : never;
 
 export { tokensToCSSVariables } from './legacy';
+export { resolveColorToken, type ColorMode } from './resolveColorToken';
+export { resolveThemeToColors } from './resolveThemeToColors';

--- a/src/theme/resolveColorToken.ts
+++ b/src/theme/resolveColorToken.ts
@@ -1,0 +1,82 @@
+import type { SystemContext } from '@chakra-ui/react';
+
+export type ColorMode = 'light' | 'dark';
+
+/**
+ * Resolves a color token to its literal value for the given color mode,
+ * following any `{token.path}` references through to a primitive.
+ *
+ * For callers that can't rely on the document's CSS custom properties being
+ * applied — e.g. Electron's `BrowserWindow.backgroundColor`, canvas/WebGL
+ * painting, or any code running in the main process — where a final hex
+ * string is required.
+ *
+ * Returns `undefined` if the token doesn't exist, has no value for the
+ * requested mode, or resolves to a non-string (e.g. `color-mix(...)` or a
+ * reference that can't be followed).
+ */
+export function resolveColorToken(
+  system: SystemContext,
+  tokenName: string,
+  mode: ColorMode
+) {
+  return resolveTokenValue(system, tokenName, mode);
+}
+
+function resolveTokenValue(
+  system: SystemContext,
+  tokenName: string,
+  mode: ColorMode,
+  seen = new Set<string>()
+) {
+  if (seen.has(tokenName)) {
+    return undefined;
+  }
+  seen.add(tokenName);
+
+  const token = system.tokens.getByName(tokenName);
+  if (!token) {
+    return undefined;
+  }
+
+  const raw = pickConditionValue(token.extensions.conditions, mode);
+  // oxlint-disable-next-line typescript/no-unsafe-assignment
+  const value = raw ?? token.originalValue;
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const referenced = matchTokenReference(value);
+  if (referenced) {
+    return resolveTokenValue(system, referenced, mode, seen);
+  }
+
+  return value;
+}
+
+// Chakra types token conditions as `Dict = Record<string, any>`. For color
+// tokens we only care about the mode-specific entries, so narrow to those.
+interface ColorConditions {
+  _light?: unknown;
+  _dark?: unknown;
+}
+
+function pickConditionValue(
+  conditions: ColorConditions | undefined,
+  mode: ColorMode
+) {
+  const value = conditions?.[mode === 'dark' ? '_dark' : '_light'];
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+// Chakra writes token references as `{category.path.to.token}`. Reject values
+// that only contain a reference as part of a larger expression (e.g.
+// `color-mix(in srgb, white 50%, {colors.levels.sunken})`); those can't be
+// reduced to a single hex without evaluating the CSS function.
+function matchTokenReference(value: string) {
+  const match = /^\{([^}]+)}$/.exec(value.trim());
+
+  return match ? match[1] : undefined;
+}

--- a/src/theme/resolveColorToken.ts
+++ b/src/theme/resolveColorToken.ts
@@ -3,17 +3,21 @@ import type { SystemContext } from '@chakra-ui/react';
 export type ColorMode = 'light' | 'dark';
 
 /**
- * Resolves a color token to its literal value for the given color mode,
- * following any `{token.path}` references through to a primitive.
+ * Resolves a color token to a CSS color string for the given color mode,
+ * recursively substituting any `{token.path}` references in the value.
  *
  * For callers that can't rely on the document's CSS custom properties being
- * applied — e.g. Electron's `BrowserWindow.backgroundColor`, canvas/WebGL
- * painting, or any code running in the main process — where a final hex
- * string is required.
+ * applied — e.g. canvas/WebGL painting, or any code running outside the
+ * rendered DOM.
+ *
+ * Simple tokens reduce to a primitive like `#FF0000` or `rgba(...)`. Tokens
+ * whose value is a CSS expression such as
+ * `color-mix(in srgb, white 50%, {colors.levels.sunken})` reduce to the same
+ * expression with references substituted — the consumer still needs to be
+ * able to render whatever CSS color syntax the token uses.
  *
  * Returns `undefined` if the token doesn't exist, has no value for the
- * requested mode, or resolves to a non-string (e.g. `color-mix(...)` or a
- * reference that can't be followed).
+ * requested mode, or contains an unresolvable / cyclic reference.
  */
 export function resolveColorToken(
   system: SystemContext,
@@ -28,7 +32,7 @@ function resolveTokenValue(
   tokenName: string,
   mode: ColorMode,
   seen = new Set<string>()
-) {
+): string | undefined {
   if (seen.has(tokenName)) {
     return undefined;
   }
@@ -47,12 +51,7 @@ function resolveTokenValue(
     return undefined;
   }
 
-  const referenced = matchTokenReference(value);
-  if (referenced) {
-    return resolveTokenValue(system, referenced, mode, seen);
-  }
-
-  return value;
+  return substituteReferences(system, value, mode, seen);
 }
 
 // Chakra types token conditions as `Dict = Record<string, any>`. For color
@@ -71,12 +70,29 @@ function pickConditionValue(
   return typeof value === 'string' ? value : undefined;
 }
 
-// Chakra writes token references as `{category.path.to.token}`. Reject values
-// that only contain a reference as part of a larger expression (e.g.
-// `color-mix(in srgb, white 50%, {colors.levels.sunken})`); those can't be
-// reduced to a single hex without evaluating the CSS function.
-function matchTokenReference(value: string) {
-  const match = /^\{([^}]+)}$/.exec(value.trim());
+// Chakra writes token references as `{category.path.to.token}`. Replace every
+// occurrence with its resolved value so references embedded inside CSS
+// expressions (e.g. `color-mix(in srgb, white 50%, {colors.levels.sunken})`)
+// get reduced as well. Siblings each get their own copy of `seen` so one
+// branch's ancestors don't leak into another's cycle check.
+function substituteReferences(
+  system: SystemContext,
+  value: string,
+  mode: ColorMode,
+  seen: Set<string>
+) {
+  let result = '';
+  let lastIndex = 0;
 
-  return match ? match[1] : undefined;
+  for (const match of value.matchAll(/\{([^}]+)}/g)) {
+    const resolved = resolveTokenValue(system, match[1], mode, new Set(seen));
+    if (resolved === undefined) {
+      return undefined;
+    }
+
+    result += value.slice(lastIndex, match.index) + resolved;
+    lastIndex = match.index + match[0].length;
+  }
+
+  return result + value.slice(lastIndex);
 }

--- a/src/theme/resolveThemeToColors.ts
+++ b/src/theme/resolveThemeToColors.ts
@@ -8,7 +8,7 @@ type ResolvedTheme<T> = T extends string
       ? { [K in keyof T]: ResolvedTheme<T[K]> }
       : never;
 
-export function resolveThemeToColors<T extends Record<string, ThemeValue>>(
+export function resolveThemeToColors<T extends ThemeValue>(
   theme: T
 ): ResolvedTheme<T> {
   const styles = getComputedStyle(document.documentElement);

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,10 +1,10 @@
 import { BBLP_THEME } from './bblp';
 import { MC_THEME } from './mc';
-import { system, TELEPORT_THEME } from './teleport';
+import { resolveTeleportColor, system, TELEPORT_THEME } from './teleport';
 
 export const THEMES = [BBLP_THEME, MC_THEME, TELEPORT_THEME];
 
-export { BBLP_THEME, MC_THEME, TELEPORT_THEME };
+export { BBLP_THEME, MC_THEME, resolveTeleportColor, TELEPORT_THEME };
 
 // This is nonsense, but rollup will remove the `system` export from the Teleport theme if
 // it is not exported or doesn't modify the global state. We need `system` to be exported

--- a/src/themes/teleport/index.ts
+++ b/src/themes/teleport/index.ts
@@ -1,1 +1,1 @@
-export { system, TELEPORT_THEME } from './theme';
+export { resolveTeleportColor, system, TELEPORT_THEME } from './theme';

--- a/src/themes/teleport/theme.ts
+++ b/src/themes/teleport/theme.ts
@@ -22,10 +22,11 @@ export const TELEPORT_THEME: UiTheme = {
 };
 
 /**
- * Resolves a teleport color token to its literal hex for the given color mode.
- * Thin wrapper over {@link resolveColorToken} bound to the teleport system,
- * for callers that can't rely on CSS custom properties (e.g. the Electron
- * main process).
+ * Resolves a teleport color token to a CSS color string for the given color
+ * mode, substituting any embedded `{token.path}` references. Thin wrapper
+ * over {@link resolveColorToken} bound to the teleport system, for callers
+ * that can't rely on CSS custom properties (e.g. canvas/WebGL painting or
+ * the Electron main process).
  */
 export function resolveTeleportColor(tokenName: string, mode: ColorMode) {
   return resolveColorToken(system, tokenName, mode);

--- a/src/themes/teleport/theme.ts
+++ b/src/themes/teleport/theme.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@chakra-ui/react';
 
 import { createThemeSystem } from '../../theme';
+import { resolveColorToken, type ColorMode } from '../../theme';
 import { UiThemeMode, type UiTheme } from '../theme';
 import { colors } from './colors';
 
@@ -19,3 +20,13 @@ export const TELEPORT_THEME: UiTheme = {
   name: 'teleport',
   config,
 };
+
+/**
+ * Resolves a teleport color token to its literal hex for the given color mode.
+ * Thin wrapper over {@link resolveColorToken} bound to the teleport system,
+ * for callers that can't rely on CSS custom properties (e.g. the Electron
+ * main process).
+ */
+export function resolveTeleportColor(tokenName: string, mode: ColorMode) {
+  return resolveColorToken(system, tokenName, mode);
+}


### PR DESCRIPTION
Exports the existing `resolveThemeToColors` which resolves a sub-section of the theme (an object which has CSS variables as the values) to their computed CSS values (useful for stuff like xterm that need the actual values)

Exports a new `resolveTeleportColor` which wraps `resolveColorToken` which helps resolve an individual token to the actual value from the theme (useful for Connect which needs the background colour on launch and cannot use the computed CSS value)