### PR TITLE
Fix `resolveColorToken` returning empty for conditional tokens

### DIFF
--- a/.changeset/wicked-cups-build.md
+++ b/.changeset/wicked-cups-build.md
@@ -1,0 +1,5 @@
+---
+'@gravitational/design-system': patch
+---
+
+Fix `resolveColorToken` returning empty for conditional tokens

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev -p 6006",
     "prebuild-storybook": "pnpm generate-theme",
     "build-storybook": "storybook build",
-    "test": "vitest --project=storybook && cd bot && pnpm test",
+    "test": "vitest --project=storybook --project=unit && cd bot && pnpm test",
     "pack-release": "cd dist && pnpm pack --out package.tgz",
     "release": "changeset publish",
     "generate": "pnpm generate-icons && pnpm generate-props",

--- a/src/theme/resolveColorToken.test.ts
+++ b/src/theme/resolveColorToken.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { createThemeSystem } from './index';
+import { resolveColorToken } from './resolveColorToken';
+import { BBLP_THEME, TELEPORT_THEME } from '../themes';
+
+const teleportSystem = createThemeSystem(TELEPORT_THEME.config);
+const bblpSystem = createThemeSystem(BBLP_THEME.config);
+
+describe('resolveColorToken (teleport theme, conditional tokens)', () => {
+  it('resolves a `{_light, _dark}` token to its dark value', () => {
+    // terminal.foreground is defined as { _light: '#000', _dark: '#FFF' }
+    expect(
+      resolveColorToken(teleportSystem, 'colors.terminal.foreground', 'dark')
+    ).toBe('#FFF');
+  });
+
+  it('resolves a `{_light, _dark}` token to its light value', () => {
+    expect(
+      resolveColorToken(teleportSystem, 'colors.terminal.foreground', 'light')
+    ).toBe('#000');
+  });
+
+  it('resolves a token whose conditional value references another conditional token', () => {
+    // terminal.red references colors.dataVisualisation.{primary|tertiary}.abbey,
+    // which itself is conditional. The result must follow the same mode.
+    const dark = resolveColorToken(
+      teleportSystem,
+      'colors.terminal.red',
+      'dark'
+    );
+    const light = resolveColorToken(
+      teleportSystem,
+      'colors.terminal.red',
+      'light'
+    );
+
+    // Both should be defined hex strings; sanity-check the format rather than
+    // duplicating the palette values here.
+    expect(dark).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(light).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(dark).not.toBe(light);
+  });
+
+  it('resolves the brand token in both modes', () => {
+    // brand is defined as { _light: '#512FC9', _dark: '#9F85FF' }
+    expect(resolveColorToken(teleportSystem, 'colors.brand', 'dark')).toBe(
+      '#9F85FF'
+    );
+    expect(resolveColorToken(teleportSystem, 'colors.brand', 'light')).toBe(
+      '#512FC9'
+    );
+  });
+
+  it('resolves a token whose value is a CSS expression with an embedded reference', () => {
+    // tooltip.background is defined as
+    //   `color-mix(in srgb, white|black 80%, {colors.levels.sunken})`.
+    // The inner reference must be substituted while the surrounding
+    // `color-mix(...)` expression is preserved verbatim.
+    const result = resolveColorToken(
+      teleportSystem,
+      'colors.tooltip.background',
+      'dark'
+    );
+    expect(result).toBeDefined();
+    expect(result).toContain('color-mix');
+    expect(result).not.toContain('{');
+  });
+
+  it('returns undefined for a token that does not exist', () => {
+    expect(
+      resolveColorToken(teleportSystem, 'colors.does.not.exist', 'dark')
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveColorToken (bblp theme, single-color tokens)', () => {
+  it('resolves a base-only token to its value regardless of mode', () => {
+    // bblp brand is `{ value: '#FFA028' }` — no `_light`/`_dark` split.
+    expect(resolveColorToken(bblpSystem, 'colors.brand', 'dark')).toBe(
+      '#FFA028'
+    );
+    expect(resolveColorToken(bblpSystem, 'colors.brand', 'light')).toBe(
+      '#FFA028'
+    );
+  });
+
+  it('resolves a nested base-only token', () => {
+    // levels.surface is `{ value: '#232323' }`
+    expect(resolveColorToken(bblpSystem, 'colors.levels.surface', 'dark')).toBe(
+      '#232323'
+    );
+  });
+
+  it('resolves a base-only token that references another base-only token', () => {
+    // terminal.background references `{colors.levels.sunken}` which is a
+    // base-only hex. The reference must be substituted to the final color.
+    const result = resolveColorToken(
+      bblpSystem,
+      'colors.terminal.background',
+      'dark'
+    );
+    expect(result).toBeDefined();
+    expect(result).not.toContain('{');
+    expect(result).not.toContain('var(');
+  });
+
+  it('returns undefined for a token that does not exist', () => {
+    expect(
+      resolveColorToken(bblpSystem, 'colors.does.not.exist', 'light')
+    ).toBeUndefined();
+  });
+});

--- a/src/theme/resolveColorToken.ts
+++ b/src/theme/resolveColorToken.ts
@@ -4,7 +4,8 @@ export type ColorMode = 'light' | 'dark';
 
 /**
  * Resolves a color token to a CSS color string for the given color mode,
- * recursively substituting any `{token.path}` references in the value.
+ * recursively substituting any `{token.path}` and `var(--...)` references in
+ * the value.
  *
  * For callers that can't rely on the document's CSS custom properties being
  * applied — e.g. canvas/WebGL painting, or any code running outside the
@@ -33,48 +34,61 @@ function resolveTokenValue(
   mode: ColorMode,
   seen = new Set<string>()
 ): string | undefined {
-  if (seen.has(tokenName)) {
-    return undefined;
-  }
-  seen.add(tokenName);
-
-  const token = system.tokens.getByName(tokenName);
-  if (!token) {
+  const cssVar = lookupCssVar(system, tokenName);
+  if (cssVar === undefined) {
     return undefined;
   }
 
-  const raw = pickConditionValue(token.extensions.conditions, mode);
-  // oxlint-disable-next-line typescript/no-unsafe-assignment
-  const value = raw ?? token.originalValue;
+  return resolveCssVar(system, cssVar, mode, seen);
+}
 
-  if (typeof value !== 'string') {
+// Chakra v3 splits semantic tokens with `{ _light, _dark }` values into one
+// sub-token per condition, all sharing the same name. `tokenMap.get(name)`
+// only retains the last one registered, so the original conditions map and
+// the per-mode values aren't reachable from a single token lookup. The
+// resolved per-mode values live in `tokens.cssVarMap`, keyed by condition and
+// then by CSS variable name (e.g. `'--teleport-colors-terminal-foreground'`).
+// Single-color themes (e.g. bblp) skip the conditional split entirely and
+// store their values under the `'base'` condition.
+function resolveCssVar(
+  system: SystemContext,
+  cssVar: string,
+  mode: ColorMode,
+  seen: Set<string>
+): string | undefined {
+  if (seen.has(cssVar)) {
+    return undefined;
+  }
+  seen.add(cssVar);
+
+  const { cssVarMap } = system.tokens;
+  const value =
+    cssVarMap.get(`_${mode}`)?.get(cssVar) ??
+    cssVarMap.get('base')?.get(cssVar);
+
+  if (typeof value !== 'string' || value === '') {
     return undefined;
   }
 
   return substituteReferences(system, value, mode, seen);
 }
 
-// Chakra types token conditions as `Dict = Record<string, any>`. For color
-// tokens we only care about the mode-specific entries, so narrow to those.
-interface ColorConditions {
-  _light?: unknown;
-  _dark?: unknown;
+// Look up the CSS variable name (e.g. `--teleport-colors-brand`) for a Chakra
+// token name (e.g. `colors.brand`). After Chakra's conditional split there's
+// no guarantee `getByName` returns the base form, but every variant carries
+// the same `extensions.cssVar`, so the first match is enough.
+function lookupCssVar(system: SystemContext, tokenName: string) {
+  return system.tokens.getByName(tokenName)?.extensions.cssVar?.var;
 }
 
-function pickConditionValue(
-  conditions: ColorConditions | undefined,
-  mode: ColorMode
-) {
-  const value = conditions?.[mode === 'dark' ? '_dark' : '_light'];
-
-  return typeof value === 'string' ? value : undefined;
-}
-
-// Chakra writes token references as `{category.path.to.token}`. Replace every
-// occurrence with its resolved value so references embedded inside CSS
-// expressions (e.g. `color-mix(in srgb, white 50%, {colors.levels.sunken})`)
-// get reduced as well. Siblings each get their own copy of `seen` so one
-// branch's ancestors don't leak into another's cycle check.
+// Chakra writes references either as `{category.path.to.token}` (in tokens
+// that reference other tokens whose own value is conditional and therefore
+// can't be eagerly expanded) or as `var(--name)` (everything else, after the
+// `tokens/conditionals` transform substitutes them). Replace both, so values
+// like `color-mix(in srgb, white 50%, {colors.levels.sunken})` and
+// `var(--teleport-colors-data-visualisation-primary-abbey)` both reduce to
+// concrete colors. Each match gets its own copy of `seen` so siblings don't
+// share a cycle check.
 function substituteReferences(
   system: SystemContext,
   value: string,
@@ -84,8 +98,13 @@ function substituteReferences(
   let result = '';
   let lastIndex = 0;
 
-  for (const match of value.matchAll(/\{([^}]+)}/g)) {
-    const resolved = resolveTokenValue(system, match[1], mode, new Set(seen));
+  for (const match of value.matchAll(/var\((--[a-z0-9-]+)\)|\{([^}]+)}/gi)) {
+    // One of the two alternatives in the regex is always captured.
+    const [, cssVarMatch, tokenNameMatch] = match;
+    const resolved = cssVarMatch
+      ? resolveCssVar(system, cssVarMatch, mode, new Set(seen))
+      : resolveTokenValue(system, tokenNameMatch, mode, new Set(seen));
+
     if (resolved === undefined) {
       return undefined;
     }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -36,6 +36,14 @@ const config: UserConfig = {
           },
         },
       },
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+        },
+      },
     ],
   },
 };


### PR DESCRIPTION
I think I was testing with a Vite cached dependency before the change to include the system in the resolution...

This fixes `resolveColorToken` to correctly return the wanted color value, and adds tests to assert that it works