### PR TITLE
Add dev-release PR artifact workflow

### DIFF
--- a/.github/workflows/dev-release-cleanup.yml
+++ b/.github/workflows/dev-release-cleanup.yml
@@ -35,10 +35,17 @@ jobs:
           TAG: dev-pr-${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          set +e
+          view_err=$(gh release view "$TAG" 2>&1 >/dev/null)
+          view_rc=$?
+          set -e
+          if [ "$view_rc" -eq 0 ]; then
             gh release delete "$TAG" --cleanup-tag --yes
-          else
+          elif printf '%s' "$view_err" | grep -qi 'release not found'; then
             echo "No release ${TAG} found; nothing to delete."
+          else
+            echo "Failed to look up release ${TAG} (rc=${view_rc}): ${view_err}" >&2
+            exit 1
           fi
 
       - name: Setup pnpm

--- a/.github/workflows/dev-release-cleanup.yml
+++ b/.github/workflows/dev-release-cleanup.yml
@@ -1,7 +1,7 @@
 name: Dev Release Cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed, unlabeled]
 
 env:

--- a/.github/workflows/dev-release-cleanup.yml
+++ b/.github/workflows/dev-release-cleanup.yml
@@ -12,14 +12,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
 jobs:
   cleanup:
-    name: Remove dev release artifact
+    name: Remove dev release
     if: |
       github.event.action == 'closed' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'dev-release')
@@ -30,48 +29,24 @@ jobs:
         with:
           ref: main
 
-      - name: Delete dev-release artifacts
-        uses: actions/github-script@v7
+      - name: Delete dev release
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        with:
-          script: |
-            const artifactName = `dev-release-pr-${process.env.PR_NUMBER}`;
-
-            const artifacts = await github.paginate(
-              github.rest.actions.listArtifactsForRepo,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: artifactName,
-                per_page: 100,
-              }
-            );
-
-            if (artifacts.length === 0) {
-              core.info(`No artifacts named ${artifactName} found; nothing to delete.`);
-              return;
-            }
-
-            for (const artifact of artifacts) {
-              try {
-                await github.rest.actions.deleteArtifact({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  artifact_id: artifact.id,
-                });
-                core.info(`Deleted artifact ${artifactName} (id ${artifact.id}).`);
-              } catch (err) {
-                core.warning(`Failed to delete artifact ${artifact.id}: ${err.message}`);
-              }
-            }
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: dev-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --cleanup-tag --yes
+          else
+            echo "No release ${TAG} found; nothing to delete."
+          fi
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Update PR comment
+      - name: Delete PR comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/dev-release-cleanup.yml
+++ b/.github/workflows/dev-release-cleanup.yml
@@ -1,0 +1,81 @@
+name: Dev Release Cleanup
+
+on:
+  pull_request:
+    types: [closed, unlabeled]
+
+env:
+  NODE_VERSION: 24.x
+
+concurrency:
+  group: dev-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  cleanup:
+    name: Remove dev release artifact
+    if: |
+      github.event.action == 'closed' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'dev-release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Delete dev-release artifacts
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const artifactName = `dev-release-pr-${process.env.PR_NUMBER}`;
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: artifactName,
+                per_page: 100,
+              }
+            );
+
+            if (artifacts.length === 0) {
+              core.info(`No artifacts named ${artifactName} found; nothing to delete.`);
+              return;
+            }
+
+            for (const artifact of artifacts) {
+              try {
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                });
+                core.info(`Deleted artifact ${artifactName} (id ${artifact.id}).`);
+              } catch (err) {
+                core.warning(`Failed to delete artifact ${artifact.id}: ${err.message}`);
+              }
+            }
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Update PR comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm bot dev-release cleanup \
+            --owner ${{ github.repository_owner }} \
+            --repo ${{ github.event.repository.name }} \
+            --pull-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,7 +1,7 @@
 name: Dev Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize, reopened]
 
 env:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
@@ -22,8 +22,10 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dev-release')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout PR head
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm with cache
         uses: ./.github/actions/setup-pnpm
@@ -33,14 +35,37 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Upload package tarball
-        id: upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-release-pr-${{ github.event.pull_request.number }}
-          path: ./dist/package.tgz
-          retention-days: 90
-          overwrite: true
+      - name: Stage tarball with SHA filename
+        id: stage
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          short=${SHA:0:7}
+          asset="design-system-${short}.tgz"
+          cp dist/package.tgz "dist/${asset}"
+          echo "asset=${asset}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to PR dev release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: dev-pr-${{ github.event.pull_request.number }}
+          ASSET: dist/${{ steps.stage.outputs.asset }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          notes="Development build for PR #${PR}. This release is automatically deleted when the PR is closed or the \`dev-release\` label is removed."
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --target "$SHA" --notes "$notes"
+            gh release upload "$TAG" "$ASSET" --clobber
+          else
+            gh release create "$TAG" "$ASSET" \
+              --prerelease \
+              --target "$SHA" \
+              --title "Dev release for PR #${PR}" \
+              --notes "$notes"
+          fi
 
       - name: Post dev-release comment
         env:
@@ -51,6 +76,5 @@ jobs:
             --repo ${{ github.event.repository.name }} \
             --pull-number ${{ github.event.pull_request.number }} \
             --sha ${{ github.event.pull_request.head.sha }} \
-            --run-id ${{ github.run_id }} \
-            --artifact-id ${{ steps.upload.outputs.artifact-id }} \
-            --artifact-name dev-release-pr-${{ github.event.pull_request.number }}
+            --tag dev-pr-${{ github.event.pull_request.number }} \
+            --asset-name ${{ steps.stage.outputs.asset }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,56 @@
+name: Dev Release
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+env:
+  NODE_VERSION: 24.x
+
+concurrency:
+  group: dev-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    name: Build dev release
+    if: contains(github.event.pull_request.labels.*.name, 'dev-release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm with cache
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload package tarball
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-pr-${{ github.event.pull_request.number }}
+          path: ./dist/package.tgz
+          retention-days: 90
+          overwrite: true
+
+      - name: Post dev-release comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm bot dev-release post \
+            --owner ${{ github.repository_owner }} \
+            --repo ${{ github.event.repository.name }} \
+            --pull-number ${{ github.event.pull_request.number }} \
+            --sha ${{ github.event.pull_request.head.sha }} \
+            --run-id ${{ github.run_id }} \
+            --artifact-id ${{ steps.upload.outputs.artifact-id }} \
+            --artifact-name dev-release-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v5
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm with cache

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -11,16 +11,17 @@ concurrency:
   group: dev-release-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   build:
     name: Build dev release
     if: contains(github.event.pull_request.labels.*.name, 'dev-release')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      asset: ${{ steps.stage.outputs.asset }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v5
@@ -45,11 +46,64 @@ jobs:
           cp dist/package.tgz "dist/${asset}"
           echo "asset=${asset}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload to PR dev release
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-tarball
+          path: dist/${{ steps.stage.outputs.asset }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish dev release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout main (trusted)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup pnpm with cache
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: dev-release-tarball
+          path: ./tarball
+
+      - name: Verify tarball matches expected name
+        id: asset
+        env:
+          ASSET: ${{ needs.build.outputs.asset }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          short=${SHA:0:7}
+          expected="design-system-${short}.tgz"
+          if [ "$ASSET" != "$expected" ]; then
+            echo "Build asset name '$ASSET' does not match expected '$expected'." >&2
+            exit 1
+          fi
+          if [ ! -f "tarball/${expected}" ]; then
+            echo "Expected tarball ./tarball/${expected} not found:" >&2
+            ls -la tarball >&2
+            exit 1
+          fi
+          echo "name=${expected}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR dev release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: dev-pr-${{ github.event.pull_request.number }}
-          ASSET: dist/${{ steps.stage.outputs.asset }}
+          ASSET_PATH: tarball/${{ steps.asset.outputs.name }}
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -58,9 +112,9 @@ jobs:
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --target "$SHA" --notes "$notes"
-            gh release upload "$TAG" "$ASSET" --clobber
+            gh release upload "$TAG" "$ASSET_PATH" --clobber
           else
-            gh release create "$TAG" "$ASSET" \
+            gh release create "$TAG" "$ASSET_PATH" \
               --prerelease \
               --target "$SHA" \
               --title "Dev release for PR #${PR}" \
@@ -77,4 +131,4 @@ jobs:
             --pull-number ${{ github.event.pull_request.number }} \
             --sha ${{ github.event.pull_request.head.sha }} \
             --tag dev-pr-${{ github.event.pull_request.number }} \
-            --asset-name ${{ steps.stage.outputs.asset }}
+            --asset-name ${{ steps.asset.outputs.name }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -16,7 +16,9 @@ permissions: {}
 jobs:
   build:
     name: Build dev release
-    if: contains(github.event.pull_request.labels.*.name, 'dev-release')
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'dev-release')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +28,6 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm with cache

--- a/bot/commands/dev-release/dev-release.ts
+++ b/bot/commands/dev-release/dev-release.ts
@@ -30,42 +30,23 @@ const postCommand = command({
     sha: option({
       type: string,
       long: 'sha',
-      description: 'Commit SHA the artifact was built from',
+      description: 'Commit SHA the tarball was built from',
     }),
-    runId: option({
+    tag: option({
       type: string,
-      long: 'run-id',
-      description: 'Workflow run ID that produced the artifact',
+      long: 'tag',
+      description: 'Release tag the tarball is attached to',
     }),
-    artifactId: option({
+    assetName: option({
       type: string,
-      long: 'artifact-id',
-      description: 'ID of the uploaded artifact',
-    }),
-    artifactName: option({
-      type: string,
-      long: 'artifact-name',
-      description: 'Name of the uploaded artifact',
+      long: 'asset-name',
+      description: 'Filename of the tarball asset',
     }),
   },
-  handler: async ({
-    owner,
-    repo,
-    pullNumber,
-    sha,
-    runId,
-    artifactId,
-    artifactName,
-  }) => {
+  handler: async ({ owner, repo, pullNumber, sha, tag, assetName }) => {
     const octokit = createOctokit();
-    const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${artifactId}`;
-    const body = renderActiveBody({
-      owner,
-      repo,
-      sha,
-      artifactUrl,
-      artifactName,
-    });
+    const tarballUrl = `https://github.com/${owner}/${repo}/releases/download/${tag}/${assetName}`;
+    const body = renderBody({ owner, repo, sha, tarballUrl });
 
     await upsertComment(octokit, owner, repo, pullNumber, body);
   },
@@ -102,17 +83,16 @@ const cleanupCommand = command({
     });
 
     if (commentId == null) {
-      core.info('No dev-release comment to clean up.');
+      core.info('No dev-release comment to delete.');
       return;
     }
 
-    await octokit.rest.issues.updateComment({
+    await octokit.rest.issues.deleteComment({
       owner,
       repo,
       comment_id: commentId,
-      body: renderArchivedBody(),
     });
-    core.info(`Marked dev-release comment ${commentId} as archived.`);
+    core.info(`Deleted dev-release comment ${commentId}.`);
   },
 });
 
@@ -157,18 +137,16 @@ async function upsertComment(
   }
 }
 
-function renderActiveBody({
+function renderBody({
   owner,
   repo,
   sha,
-  artifactUrl,
-  artifactName,
+  tarballUrl,
 }: {
   owner: string;
   repo: string;
   sha: string;
-  artifactUrl: string;
-  artifactName: string;
+  tarballUrl: string;
 }) {
   const shortSha = sha.slice(0, 7);
   const commitUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
@@ -176,27 +154,18 @@ function renderActiveBody({
   return `${COMMENT_MARKER}
 ### 📦 Dev Release
 
-A development build of this PR is available as a workflow artifact.
+A dev release of \`@gravitational/design-system\` is available for this PR.
 
 - **Built from:** [\`${shortSha}\`](${commitUrl})
-- **Download:** [\`${artifactName}.zip\`](${artifactUrl})
+- **Tarball:** ${tarballUrl}
 
-The download is a zip containing \`package.tgz\`. To use it in another repo:
+Add this to your \`package.json\`:
 
-\`\`\`sh
-unzip ${artifactName}.zip
-pnpm add ./package.tgz
+\`\`\`json
+"@gravitational/design-system": "${tarballUrl}"
 \`\`\`
 
-This comment is updated when new commits are pushed. The artifact is deleted when the PR is closed or the \`dev-release\` label is removed.
-`;
-}
-
-function renderArchivedBody() {
-  return `${COMMENT_MARKER}
-### 📦 Dev Release
-
-The dev release artifact for this PR has been deleted.
+The URL changes with each commit (includes the short SHA), so update your \`package.json\` after each new commit. The release is deleted when the PR is closed or the \`dev-release\` label is removed.
 `;
 }
 

--- a/bot/commands/dev-release/dev-release.ts
+++ b/bot/commands/dev-release/dev-release.ts
@@ -108,20 +108,20 @@ async function upsertComment(
   octokit: Octokit,
   owner: string,
   repo: string,
-  pull_number: number,
+  pullNumber: number,
   body: string
 ) {
   const commentId = await getDevReleaseCommentId(octokit, {
     owner,
     repo,
-    issue_number: pull_number,
+    issue_number: pullNumber,
   });
 
   const params: RestEndpointMethodTypes['issues']['createComment']['parameters'] =
     {
       owner,
       repo,
-      issue_number: pull_number,
+      issue_number: pullNumber,
       body,
     };
 

--- a/bot/commands/dev-release/dev-release.ts
+++ b/bot/commands/dev-release/dev-release.ts
@@ -1,0 +1,217 @@
+import * as core from '@actions/core';
+import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
+import { command, number, option, string, subcommands } from 'cmd-ts';
+
+import { createOctokit } from '../../util';
+
+const COMMENT_MARKER = '<!-- design-system:dev-release -->';
+
+const postCommand = command({
+  name: 'post',
+  args: {
+    owner: option({
+      type: string,
+      long: 'owner',
+      short: 'o',
+      description: 'Repository owner',
+    }),
+    repo: option({
+      type: string,
+      long: 'repo',
+      short: 'r',
+      description: 'Repository name',
+    }),
+    pullNumber: option({
+      type: number,
+      long: 'pull-number',
+      short: 'p',
+      description: 'Pull request number',
+    }),
+    sha: option({
+      type: string,
+      long: 'sha',
+      description: 'Commit SHA the artifact was built from',
+    }),
+    runId: option({
+      type: string,
+      long: 'run-id',
+      description: 'Workflow run ID that produced the artifact',
+    }),
+    artifactId: option({
+      type: string,
+      long: 'artifact-id',
+      description: 'ID of the uploaded artifact',
+    }),
+    artifactName: option({
+      type: string,
+      long: 'artifact-name',
+      description: 'Name of the uploaded artifact',
+    }),
+  },
+  handler: async ({
+    owner,
+    repo,
+    pullNumber,
+    sha,
+    runId,
+    artifactId,
+    artifactName,
+  }) => {
+    const octokit = createOctokit();
+    const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${artifactId}`;
+    const body = renderActiveBody({
+      owner,
+      repo,
+      sha,
+      artifactUrl,
+      artifactName,
+    });
+
+    await upsertComment(octokit, owner, repo, pullNumber, body);
+  },
+});
+
+const cleanupCommand = command({
+  name: 'cleanup',
+  args: {
+    owner: option({
+      type: string,
+      long: 'owner',
+      short: 'o',
+      description: 'Repository owner',
+    }),
+    repo: option({
+      type: string,
+      long: 'repo',
+      short: 'r',
+      description: 'Repository name',
+    }),
+    pullNumber: option({
+      type: number,
+      long: 'pull-number',
+      short: 'p',
+      description: 'Pull request number',
+    }),
+  },
+  handler: async ({ owner, repo, pullNumber }) => {
+    const octokit = createOctokit();
+    const commentId = await getDevReleaseCommentId(octokit, {
+      owner,
+      repo,
+      issue_number: pullNumber,
+    });
+
+    if (commentId == null) {
+      core.info('No dev-release comment to clean up.');
+      return;
+    }
+
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body: renderArchivedBody(),
+    });
+    core.info(`Marked dev-release comment ${commentId} as archived.`);
+  },
+});
+
+export const devReleaseCommand = subcommands({
+  name: 'dev-release',
+  cmds: {
+    post: postCommand,
+    cleanup: cleanupCommand,
+  },
+});
+
+async function upsertComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pull_number: number,
+  body: string
+) {
+  const commentId = await getDevReleaseCommentId(octokit, {
+    owner,
+    repo,
+    issue_number: pull_number,
+  });
+
+  const params: RestEndpointMethodTypes['issues']['createComment']['parameters'] =
+    {
+      owner,
+      repo,
+      issue_number: pull_number,
+      body,
+    };
+
+  if (commentId != null) {
+    await octokit.rest.issues.updateComment({
+      ...params,
+      comment_id: commentId,
+    });
+    core.info(`Updated dev-release comment ${commentId}.`);
+  } else {
+    const comment = await octokit.rest.issues.createComment(params);
+    core.info(`Created dev-release comment ${comment.data.id}.`);
+  }
+}
+
+function renderActiveBody({
+  owner,
+  repo,
+  sha,
+  artifactUrl,
+  artifactName,
+}: {
+  owner: string;
+  repo: string;
+  sha: string;
+  artifactUrl: string;
+  artifactName: string;
+}) {
+  const shortSha = sha.slice(0, 7);
+  const commitUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
+
+  return `${COMMENT_MARKER}
+### 📦 Dev Release
+
+A development build of this PR is available as a workflow artifact.
+
+- **Built from:** [\`${shortSha}\`](${commitUrl})
+- **Download:** [\`${artifactName}.zip\`](${artifactUrl})
+
+The download is a zip containing \`package.tgz\`. To use it in another repo:
+
+\`\`\`sh
+unzip ${artifactName}.zip
+pnpm add ./package.tgz
+\`\`\`
+
+This comment is updated when new commits are pushed. The artifact is deleted when the PR is closed or the \`dev-release\` label is removed.
+`;
+}
+
+function renderArchivedBody() {
+  return `${COMMENT_MARKER}
+### 📦 Dev Release
+
+The dev release artifact for this PR has been deleted.
+`;
+}
+
+async function getDevReleaseCommentId(
+  octokit: Octokit,
+  params: { repo: string; owner: string; issue_number: number }
+) {
+  const comments = await octokit.paginate(
+    octokit.rest.issues.listComments,
+    params
+  );
+  const devReleaseComment = comments.find(
+    comment =>
+      comment.user?.login === 'github-actions[bot]' &&
+      comment.body?.includes(COMMENT_MARKER)
+  );
+  return devReleaseComment ? devReleaseComment.id : null;
+}

--- a/bot/index.ts
+++ b/bot/index.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import { run, subcommands } from 'cmd-ts';
 
 import { changesetCommand } from './commands/changeset/changeset';
+import { devReleaseCommand } from './commands/dev-release/dev-release';
 import { releaseCommand } from './commands/release/release';
 import { reviewCommand } from './commands/review/review';
 import { storybookCommand } from './commands/storybook/storybook';
@@ -11,6 +12,7 @@ const bot = subcommands({
   name: 'bot',
   cmds: {
     changeset: changesetCommand,
+    'dev-release': devReleaseCommand,
     release: releaseCommand,
     review: reviewCommand,
     storybook: storybookCommand,


### PR DESCRIPTION
When a PR is labeled `dev-release`, build the package tarball and upload it as a workflow artifact, then comment on the PR with a download link and the SHA it was built from. The comment is updated on subsequent pushes; the artifact and comment are cleaned up when the PR is closed or the label is removed.