### PR TITLE
Add a workflow for nuking Storybook previews

### DIFF
--- a/.github/workflows/storybook-nuke.yml
+++ b/.github/workflows/storybook-nuke.yml
@@ -1,0 +1,109 @@
+name: Storybook Nuke Previews
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: PR number whose preview to keep (all other previews are nuked)
+        required: true
+
+permissions:
+  actions: write
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+  issues: write
+
+env:
+  NODE_VERSION: 24.x
+
+jobs:
+  purge:
+    name: Delete other PR preview artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'nuke-previews'
+    outputs:
+      authorized: ${{ steps.nuke.outputs.authorized }}
+    env:
+      PULL_NUMBER: ${{ github.event.pull_request.number || inputs.pull_number }}
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup pnpm with cache
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Authorize and delete other PR previews
+        id: nuke
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          pnpm bot storybook nuke-previews \
+            --owner ${{ github.repository_owner }} \
+            --repo ${{ github.event.repository.name }} \
+            --pull-number "$PULL_NUMBER" \
+            --actor "$ACTOR"
+
+  redeploy:
+    name: Redeploy Pages keeping only the labeled PR's preview
+    runs-on: ubuntu-latest
+    needs: purge
+    if: needs.purge.outputs.authorized == 'true'
+    concurrency:
+      group: storybook-deployment
+      cancel-in-progress: false
+    env:
+      PULL_NUMBER: ${{ github.event.pull_request.number || inputs.pull_number }}
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup pnpm with cache
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Re-delete any previews uploaded since the purge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          pnpm bot storybook nuke-previews \
+            --owner ${{ github.repository_owner }} \
+            --repo ${{ github.event.repository.name }} \
+            --pull-number "$PULL_NUMBER" \
+            --actor "$ACTOR"
+
+      - name: Ensure main storybook build is available
+        uses: ./.github/actions/ensure-main-storybook
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Fetch remaining open PR previews
+        uses: ./.github/actions/fetch-pr-previews
+
+      - name: Assemble and deploy combined pages
+        uses: ./.github/actions/deploy-combined-pages
+
+      - name: Remove the nuke-previews label after a successful nuke
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues
+              .removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.PULL_NUMBER),
+                name: 'nuke-previews',
+              })
+              .catch(() => {});

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm bot storybook \
+          pnpm bot storybook comment \
             --owner ${{ github.repository_owner }} \
             --repo ${{ github.event.repository.name }} \
             --pull-number ${{ github.event.pull_request.number }}

--- a/bot/commands/storybook/nuke.test.ts
+++ b/bot/commands/storybook/nuke.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isGroup1Reviewer,
+  runNukePreviews,
+  selectPreviewArtifactsToDelete,
+} from './nuke';
+
+vi.mock('@actions/core', () => ({
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  setFailed: vi.fn(),
+  setOutput: vi.fn(),
+}));
+
+describe('isGroup1Reviewer', () => {
+  it('accepts group 1 reviewers (eu and us)', () => {
+    expect(isGroup1Reviewer('ryanclark')).toBe(true);
+    expect(isGroup1Reviewer('ravicious')).toBe(true);
+    expect(isGroup1Reviewer('avatus')).toBe(true);
+    expect(isGroup1Reviewer('kimlisa')).toBe(true);
+  });
+
+  it('rejects group 2 reviewers and everyone else', () => {
+    expect(isGroup1Reviewer('bl-nero')).toBe(false);
+    expect(isGroup1Reviewer('some-random-user')).toBe(false);
+    expect(isGroup1Reviewer('')).toBe(false);
+  });
+});
+
+describe('selectPreviewArtifactsToDelete', () => {
+  const artifacts = [
+    { id: 1, name: 'storybook-pr-12' },
+    { id: 2, name: 'storybook-pr-7' },
+    { id: 3, name: 'storybook-main' },
+    { id: 4, name: 'storybook-pr-abc' },
+    { id: 5, name: 'unrelated' },
+    { id: 6, name: 'storybook-pr-' },
+  ];
+
+  it('deletes other PR previews but keeps the labeled PR and non-preview artifacts', () => {
+    expect(
+      selectPreviewArtifactsToDelete(artifacts, 12).map(a => a.id)
+    ).toEqual([2]);
+  });
+
+  it('deletes every PR preview when the labeled PR has none of its own', () => {
+    expect(
+      selectPreviewArtifactsToDelete(artifacts, 999).map(a => a.id)
+    ).toEqual([1, 2]);
+  });
+});
+
+interface FakeOctokit {
+  paginate: ReturnType<typeof vi.fn>;
+  rest: {
+    issues: {
+      removeLabel: ReturnType<typeof vi.fn>;
+      createComment: ReturnType<typeof vi.fn>;
+    };
+    actions: {
+      listArtifactsForRepo: ReturnType<typeof vi.fn>;
+      deleteArtifact: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function fakeOctokit(artifacts: { id: number; name: string }[]): FakeOctokit {
+  return {
+    paginate: vi.fn(() => Promise.resolve(artifacts)),
+    rest: {
+      issues: {
+        removeLabel: vi.fn(() => Promise.resolve()),
+        createComment: vi.fn(() => Promise.resolve()),
+      },
+      actions: {
+        listArtifactsForRepo: vi.fn(),
+        deleteArtifact: vi.fn(() => Promise.resolve()),
+      },
+    },
+  };
+}
+
+describe('runNukePreviews', () => {
+  const ctx = { owner: 'o', repo: 'r', pullNumber: 12, actor: 'ryanclark' };
+
+  it('deletes other previews and returns true for a group 1 reviewer', async () => {
+    const octokit = fakeOctokit([
+      { id: 1, name: 'storybook-pr-12' },
+      { id: 2, name: 'storybook-pr-7' },
+      { id: 3, name: 'storybook-main' },
+    ]);
+
+    const ok = await runNukePreviews(octokit as never, ctx);
+
+    expect(ok).toBe(true);
+    expect(octokit.rest.actions.deleteArtifact).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.actions.deleteArtifact).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      artifact_id: 2,
+    });
+    expect(octokit.rest.issues.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it('removes the label, comments, deletes nothing, and returns false for a non-group-1 actor', async () => {
+    const octokit = fakeOctokit([{ id: 2, name: 'storybook-pr-7' }]);
+
+    const ok = await runNukePreviews(octokit as never, {
+      ...ctx,
+      actor: 'mallory',
+    });
+
+    expect(ok).toBe(false);
+    expect(octokit.rest.actions.deleteArtifact).not.toHaveBeenCalled();
+    expect(octokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 12,
+        name: 'nuke-previews',
+      })
+    );
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws (and does not resolve true) when a targeted deletion fails', async () => {
+    const octokit = fakeOctokit([
+      { id: 1, name: 'storybook-pr-12' },
+      { id: 2, name: 'storybook-pr-7' },
+    ]);
+    octokit.rest.actions.deleteArtifact = vi.fn(() =>
+      Promise.reject(new Error('boom'))
+    );
+
+    await expect(runNukePreviews(octokit as never, ctx)).rejects.toThrow(
+      /Failed to delete/
+    );
+  });
+});

--- a/bot/commands/storybook/nuke.ts
+++ b/bot/commands/storybook/nuke.ts
@@ -1,0 +1,129 @@
+import * as core from '@actions/core';
+import { Octokit } from '@octokit/rest';
+import { command, number, option, string } from 'cmd-ts';
+
+import { createOctokit, resolveErrorMessage } from '../../util';
+import { GROUP1_REVIEWERS } from '../review/common';
+
+const NUKE_LABEL = 'nuke-previews';
+const PREVIEW_ARTIFACT = /^storybook-pr-(\d+)$/;
+
+export function isGroup1Reviewer(login: string): boolean {
+  return [...GROUP1_REVIEWERS.eu, ...GROUP1_REVIEWERS.us].includes(login);
+}
+
+export function selectPreviewArtifactsToDelete<T extends { name: string }>(
+  artifacts: T[],
+  keepPullNumber: number
+): T[] {
+  return artifacts.filter(artifact => {
+    const match = PREVIEW_ARTIFACT.exec(artifact.name);
+    return match != null && Number(match[1]) !== keepPullNumber;
+  });
+}
+
+interface NukeContext {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  actor: string;
+}
+
+export async function runNukePreviews(
+  octokit: Octokit,
+  { owner, repo, pullNumber, actor }: NukeContext
+): Promise<boolean> {
+  if (!isGroup1Reviewer(actor)) {
+    core.warning(
+      `${actor} is not a group 1 reviewer; ignoring ${NUKE_LABEL} on #${pullNumber}.`
+    );
+    await octokit.rest.issues
+      .removeLabel({ owner, repo, issue_number: pullNumber, name: NUKE_LABEL })
+      .catch((err: unknown) => {
+        core.warning(`Failed to remove label: ${resolveErrorMessage(err)}`);
+      });
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body: `🚫 \`${NUKE_LABEL}\` can only be applied by a group 1 reviewer, so I've removed it. No previews were changed.`,
+    });
+    return false;
+  }
+
+  const artifacts = await octokit.paginate(
+    octokit.rest.actions.listArtifactsForRepo,
+    { owner, repo, per_page: 100 }
+  );
+
+  const toDelete = selectPreviewArtifactsToDelete(artifacts, pullNumber);
+  core.info(
+    `Deleting ${toDelete.length} preview artifact(s); keeping storybook-pr-${pullNumber}.`
+  );
+
+  const failed: string[] = [];
+  for (const artifact of toDelete) {
+    try {
+      await octokit.rest.actions.deleteArtifact({
+        owner,
+        repo,
+        artifact_id: artifact.id,
+      });
+      core.info(`Deleted ${artifact.name} (id ${artifact.id}).`);
+    } catch (err: unknown) {
+      failed.push(`${artifact.name} (${artifact.id})`);
+      core.warning(
+        `Failed to delete ${artifact.name} (${artifact.id}): ${resolveErrorMessage(err)}`
+      );
+    }
+  }
+
+  if (failed.length > 0) {
+    throw new Error(
+      `Failed to delete ${failed.length} preview artifact(s): ${failed.join(', ')}. Aborting before redeploy so they are not republished.`
+    );
+  }
+
+  return true;
+}
+
+export const storybookNukeCommand = command({
+  name: 'nuke-previews',
+  args: {
+    owner: option({
+      type: string,
+      long: 'owner',
+      short: 'o',
+      description: 'Repository owner',
+    }),
+    repo: option({
+      type: string,
+      long: 'repo',
+      short: 'r',
+      description: 'Repository name',
+    }),
+    pullNumber: option({
+      type: number,
+      long: 'pull-number',
+      short: 'p',
+      description:
+        'Pull request the label was applied to (its preview is kept)',
+    }),
+    actor: option({
+      type: string,
+      long: 'actor',
+      short: 'a',
+      description: 'GitHub login that applied the label',
+    }),
+  },
+  handler: async ({ owner, repo, pullNumber, actor }) => {
+    const octokit = createOctokit();
+    const authorized = await runNukePreviews(octokit, {
+      owner,
+      repo,
+      pullNumber,
+      actor,
+    });
+    core.setOutput('authorized', authorized ? 'true' : 'false');
+  },
+});

--- a/bot/commands/storybook/storybook.ts
+++ b/bot/commands/storybook/storybook.ts
@@ -1,11 +1,12 @@
 import * as core from '@actions/core';
 import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
-import { command, number, option, string } from 'cmd-ts';
+import { command, number, option, string, subcommands } from 'cmd-ts';
 
 import { createOctokit } from '../../util';
+import { storybookNukeCommand } from './nuke';
 
-export const storybookCommand = command({
-  name: 'storybook',
+const storybookCommentCommand = command({
+  name: 'comment',
   args: {
     owner: option({
       type: string,
@@ -30,6 +31,14 @@ export const storybookCommand = command({
     const octokit = createOctokit();
 
     await runStorybookCommand(octokit, owner, repo, pullNumber);
+  },
+});
+
+export const storybookCommand = subcommands({
+  name: 'storybook',
+  cmds: {
+    comment: storybookCommentCommand,
+    'nuke-previews': storybookNukeCommand,
   },
 });
 


### PR DESCRIPTION
This adds a workflow so a PR by a group 1 reviewer (or a manual dispatch) can nuke all the existing PR previews that are deployed if needed