### PR TITLE
Fix TypeScript resolution in CLI when using pnpm virtual store

### DIFF
--- a/.changeset/common-mice-hunt.md
+++ b/.changeset/common-mice-hunt.md
@@ -2,4 +2,4 @@
 "@gravitational/design-system": patch
 ---
 
-Add TypeScript as a peer dependency to support pnpm virtual store
+Add TypeScript as a dependency to support pnpm virtual store

--- a/.changeset/common-mice-hunt.md
+++ b/.changeset/common-mice-hunt.md
@@ -1,0 +1,5 @@
+---
+"@gravitational/design-system": patch
+---
+
+Add TypeScript as a peer dependency to support pnpm virtual store

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-table": "^8.21.3",
     "next-themes": "^0.4.6",
-    "react-hook-form": "^7.75.0"
+    "react-hook-form": "^7.75.0",
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "@emotion/react": ">=11",
@@ -105,7 +106,6 @@
     "storybook": "^10.3.6",
     "tocbot": "^4.36.6",
     "tslib": "^2.8.1",
-    "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.2",
     "usehooks-ts": "^3.1.1",
     "vite": "^8.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-hook-form:
         specifier: ^7.75.0
         version: 7.75.0(react@19.2.5)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.0
@@ -186,9 +189,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
       typescript-eslint:
         specifier: ^8.59.2
         version: 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
Adds TypeScript as a dependency so when using pnpm's global virtual store in Teleport, the CLI can import `typescript` and run the type gen