### PR TITLE
Fix Chakra type generation on Windows

### DIFF
--- a/.changeset/cuddly-adults-own.md
+++ b/.changeset/cuddly-adults-own.md
@@ -1,0 +1,5 @@
+---
+"@gravitational/design-system": patch
+---
+
+Fix Chakra type generation on Windows by resolving the generated types path from the package URL before converting it to an OS-specific filesystem path.

--- a/src/cli/addComments.ts
+++ b/src/cli/addComments.ts
@@ -187,12 +187,15 @@ async function extractRecipeVariants(filePath: string) {
 }
 
 function findGeneratedTypeFile() {
-  const styledSystem = fileURLToPath(
-    import.meta.resolve('@chakra-ui/react/styled-system')
+  const styledSystemUrl = import.meta.resolve(
+    '@chakra-ui/react/styled-system'
   );
-  const styledSystemTypes = styledSystem.replace('/esm/', '/types/');
 
-  return join(dirname(styledSystemTypes), 'generated', `recipes.gen.d.ts`);
+  const styledSystemTypes = fileURLToPath(
+    styledSystemUrl.replace('/esm/', '/types/')
+  );
+
+  return join(dirname(styledSystemTypes), 'generated', 'recipes.gen.d.ts');
 }
 
 async function updateGeneratedTypes(

--- a/src/cli/addComments.ts
+++ b/src/cli/addComments.ts
@@ -187,9 +187,7 @@ async function extractRecipeVariants(filePath: string) {
 }
 
 function findGeneratedTypeFile() {
-  const styledSystemUrl = import.meta.resolve(
-    '@chakra-ui/react/styled-system'
-  );
+  const styledSystemUrl = import.meta.resolve('@chakra-ui/react/styled-system');
 
   const styledSystemTypes = fileURLToPath(
     styledSystemUrl.replace('/esm/', '/types/')


### PR DESCRIPTION
We've been having failing builds on the `master` branch in `teleport` [ref](https://github.com/gravitational/teleport.e/actions/runs/28776727447/job/85322417272#step:7:1490).

I took a quick look and noticed that the path resolution had some issues. The current implementation does
1. Uses file URL: `file:///C:/path/to/esm/`
2. Resolves to path: `C:\path\to\esm\`
3. Replace `/esm/` -> `/types/` (string doesn't match due to backslash `\`)
4. Result `C:\path\to\esm\` (not replaced)

The fix just inverts step 2 and 3
1. Uses file URL: `file:///C:/path/to/esm/`
3. Replace `/esm/` -> `/types/` (result `file://C:/path/to/types/`)
2. Resolves to path: `C:\path\to\types\`
4. Result `C:\path\to\types\`

I haven't been able to test this since I don't have a Windows machine but I assume this should work. I can probably add tests later but I just noticed this should be a quick fix.