### PR TITLE
Allow for any 2 reviews when author is group 1

### DIFF
--- a/bot/commands/review/assign.test.ts
+++ b/bot/commands/review/assign.test.ts
@@ -39,6 +39,39 @@ describe('selectRandomReviewers', () => {
     expect(reviewers.every(r => eligibleGroup2.includes(r))).toBe(true);
   });
 
+  it('selects two reviewers from the combined group1/group2 pool for a group1 author', () => {
+    const eligibleGroup1 = ['ravicious'];
+    const eligibleGroup2 = ['bl-nero', 'gzdunek', 'nicholasmarais1158'];
+    const combined = [...eligibleGroup1, ...eligibleGroup2];
+
+    const reviewers = selectRandomReviewers(
+      eligibleGroup1,
+      eligibleGroup2,
+      false,
+      true
+    );
+
+    expect(reviewers).toHaveLength(2);
+    expect(new Set(reviewers).size).toBe(2);
+    expect(reviewers.every(r => combined.includes(r))).toBe(true);
+  });
+
+  it('can request the other group1 member for a group1 author', () => {
+    const eligibleGroup1 = ['ravicious'];
+    const eligibleGroup2 = ['bl-nero'];
+
+    const reviewers = selectRandomReviewers(
+      eligibleGroup1,
+      eligibleGroup2,
+      false,
+      true
+    );
+
+    expect(reviewers).toHaveLength(2);
+    expect(reviewers).toContain('ravicious');
+    expect(reviewers).toContain('bl-nero');
+  });
+
   it('returns empty array when no eligible reviewers', () => {
     const reviewers = selectRandomReviewers([], [], false);
 

--- a/bot/commands/review/assign.ts
+++ b/bot/commands/review/assign.ts
@@ -7,6 +7,7 @@ import {
   getPullRequestContext,
   getReviewerPool,
   getReviewState,
+  GROUP1_REVIEWERS,
   type PullRequestContext,
   type ReviewState,
 } from './common';
@@ -136,6 +137,11 @@ async function assignRandomReviewers(
   octokit: Octokit,
   context: PullRequestContext
 ) {
+  const isGroup1Author = [
+    ...GROUP1_REVIEWERS.eu,
+    ...GROUP1_REVIEWERS.us,
+  ].includes(context.author);
+
   const eligibleGroup1 = getReviewerPool(context, 'group1').filter(
     r => r !== context.author
   );
@@ -146,7 +152,8 @@ async function assignRandomReviewers(
   const reviewers = selectRandomReviewers(
     eligibleGroup1,
     eligibleGroup2,
-    context.isRelease
+    context.isRelease,
+    isGroup1Author
   );
 
   if (reviewers.length === 0) {
@@ -176,8 +183,17 @@ async function assignRandomReviewers(
 export function selectRandomReviewers(
   eligibleGroup1: string[],
   eligibleGroup2: string[],
-  isRelease: boolean
+  isRelease: boolean,
+  isGroup1Author = false
 ): string[] {
+  if (isGroup1Author && !isRelease) {
+    const pool = [...eligibleGroup1, ...eligibleGroup2].sort(
+      () => Math.random() - 0.5
+    );
+
+    return pool.slice(0, 2);
+  }
+
   const reviewers: string[] = [];
 
   if (eligibleGroup1.length > 0) {

--- a/bot/commands/review/check.test.ts
+++ b/bot/commands/review/check.test.ts
@@ -160,4 +160,100 @@ describe('validateApprovals', () => {
     expect(result.isValid).toBe(true);
     expect(result.missingGroups.group2).toBe(false);
   });
+
+  describe('group1 author', () => {
+    const group1Author: PullRequestContext = {
+      ...baseContext,
+      author: 'ryanclark',
+    };
+
+    it('passes with two approvals from any team members', () => {
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['bl-nero', 'gzdunek']),
+      };
+
+      const result = validateApprovals(group1Author, reviewState);
+
+      expect(result.isValid).toBe(true);
+      expect(result.missingGroups.group1).toBe(false);
+      expect(result.missingGroups.group2).toBe(false);
+    });
+
+    it('does not require a second group1 approval', () => {
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['ravicious', 'avatus']),
+      };
+
+      const result = validateApprovals(group1Author, reviewState);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('fails with only one approval', () => {
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['bl-nero']),
+      };
+
+      const result = validateApprovals(group1Author, reviewState);
+
+      expect(result.isValid).toBe(false);
+      expect(result.missingGroups.group2).toBe(true);
+    });
+
+    it('still requires design approval when needs-design-review is set', () => {
+      const context: PullRequestContext = {
+        ...group1Author,
+        needsDesignReview: true,
+      };
+
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['bl-nero', 'gzdunek']),
+      };
+
+      const result = validateApprovals(context, reviewState);
+
+      expect(result.isValid).toBe(false);
+      expect(result.missingGroups.design).toBe(true);
+      // the two team approvals are satisfied, so group1/group2 are not flagged
+      expect(result.missingGroups.group1).toBe(false);
+      expect(result.missingGroups.group2).toBe(false);
+    });
+
+    it('passes with two approvals plus design when required', () => {
+      const context: PullRequestContext = {
+        ...group1Author,
+        needsDesignReview: true,
+      };
+
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['bl-nero', 'gzdunek', 'roraback']),
+      };
+
+      const result = validateApprovals(context, reviewState);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('does not count a design approval toward the two required team approvals', () => {
+      const context: PullRequestContext = {
+        ...group1Author,
+        needsDesignReview: true,
+      };
+
+      const reviewState: ReviewState = {
+        ...baseReviewState,
+        approvedBy: new Set(['bl-nero', 'roraback']),
+      };
+
+      const result = validateApprovals(context, reviewState);
+
+      expect(result.isValid).toBe(false);
+      expect(result.missingGroups.group2).toBe(true);
+    });
+  });
 });

--- a/bot/commands/review/check.ts
+++ b/bot/commands/review/check.ts
@@ -78,6 +78,7 @@ async function runCheckReviewersCommand(
 
 interface ApprovalValidation {
   isValid: boolean;
+  isGroup1Author: boolean;
   missingGroups: {
     group1: boolean;
     group2: boolean;
@@ -105,11 +106,13 @@ export function validateApprovals(
   const eligibleGroup2 = group2.filter(u => u !== context.author);
   const eligibleDesign = design.filter(u => u !== context.author);
 
+  const isGroup1Author = allGroup1.includes(context.author);
   const group1Approved = allGroup1.some(u => reviewState.approvedBy.has(u));
 
   if (context.isRelease || context.isDependabot) {
     return {
       isValid: group1Approved,
+      isGroup1Author,
       missingGroups: {
         group1: !group1Approved,
         group2: false,
@@ -123,27 +126,50 @@ export function validateApprovals(
     };
   }
 
+  const designApproved = allDesign.some(u => reviewState.approvedBy.has(u));
+  const needsDesign = context.needsDesignReview && !designApproved;
+  const designSatisfied = !context.needsDesignReview || designApproved;
+
+  if (isGroup1Author) {
+    const teamApprovals = Array.from(reviewState.approvedBy).filter(
+      approver => !allDesign.includes(approver)
+    ).length;
+    const hasEnoughApprovals = teamApprovals >= 2;
+
+    return {
+      isValid: hasEnoughApprovals && designSatisfied,
+      isGroup1Author,
+      missingGroups: {
+        group1: false,
+        group2: !hasEnoughApprovals,
+        design: needsDesign,
+      },
+      eligibleReviewers: {
+        group1: [],
+        group2: eligibleGroup2,
+        design: eligibleDesign,
+      },
+    };
+  }
+
   // count any approver not in group 1 or design as group 2 whilst we do not have the full
   // team being requested for review automatically
   const group2Approved = Array.from(reviewState.approvedBy).some(
     approver => !allGroup1.includes(approver) && !allDesign.includes(approver)
   );
-  const designApproved = allDesign.some(u => reviewState.approvedBy.has(u));
 
   const hasEligibleGroup1 = eligibleGroup1.length > 0;
 
   const needsGroup1 = hasEligibleGroup1 && !group1Approved;
   const needsGroup2 = !group2Approved;
-  const needsDesign = context.needsDesignReview && !designApproved;
 
   const isValid = hasEligibleGroup1
-    ? group1Approved &&
-      group2Approved &&
-      (!context.needsDesignReview || designApproved)
-    : group2Approved && (!context.needsDesignReview || designApproved);
+    ? group1Approved && group2Approved && designSatisfied
+    : group2Approved && designSatisfied;
 
   return {
     isValid,
+    isGroup1Author,
     missingGroups: {
       group1: needsGroup1,
       group2: needsGroup2,
@@ -307,7 +333,14 @@ async function deleteRuns(
 function reportValidationFailure(validation: ApprovalValidation) {
   const failureReasons: string[] = [];
 
-  if (validation.missingGroups.group1 && validation.missingGroups.group2) {
+  if (validation.isGroup1Author) {
+    if (validation.missingGroups.group2) {
+      failureReasons.push('Needs 2 approvals from any team members.');
+    }
+  } else if (
+    validation.missingGroups.group1 &&
+    validation.missingGroups.group2
+  ) {
     failureReasons.push('Required approvals missing: group 1 and group 2.');
   } else if (validation.missingGroups.group1) {
     failureReasons.push('Required approvals missing: group 1.');
@@ -328,8 +361,10 @@ function reportValidationFailure(validation: ApprovalValidation) {
   }
 
   if (validation.missingGroups.group2) {
+    const label = validation.isGroup1Author ? 'Reviewers' : 'Group 2';
+
     core.error(
-      `Group 2: ${formatReviewers(validation.eligibleReviewers.group2)}`
+      `${label}: ${formatReviewers(validation.eligibleReviewers.group2)}`
     );
   }
 


### PR DESCRIPTION
We don't have many group 1 reviewers, so limiting group 1 PRs to a group 1 + group 2 approval increases review time and impact on reviewers